### PR TITLE
fix: Lift security group out of app construct

### DIFF
--- a/cdk/src/stack-base.ts
+++ b/cdk/src/stack-base.ts
@@ -13,6 +13,7 @@ export class BaseStack extends Stack {
   public readonly vpc: ec2.Vpc
   public readonly cluster: ecs.Cluster
   public readonly filesystem: efs.FileSystem
+  public readonly filesystemSecurityGroup: ec2.ISecurityGroup
 
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
@@ -41,8 +42,12 @@ export class BaseStack extends Stack {
       enableFargateCapacityProviders: true,
     })
 
+    this.filesystemSecurityGroup = new ec2.SecurityGroup(this, 'FileSystemSecurityGroup', {
+      vpc: this.vpc,
+    })
     this.filesystem = new efs.FileSystem(this, 'FileSystem', {
       vpc: this.vpc,
+      securityGroup: this.filesystemSecurityGroup,
     })
   }
 

--- a/cdk/src/stack-bot.ts
+++ b/cdk/src/stack-bot.ts
@@ -8,7 +8,7 @@ export class BotStack extends Stack {
   constructor(scope: Construct, id: string, props: HeyAmplifyAppStackProps) {
     super(scope, id, props)
 
-    const { cluster, filesystem } = props
+    const { cluster, filesystem, filesystemSecurityGroup } = props
 
     const secrets = {
       DISCORD_BOT_TOKEN: props.secrets.DISCORD_BOT_TOKEN,
@@ -23,6 +23,7 @@ export class BotStack extends Stack {
       },
       secrets,
       filesystem,
+      filesystemSecurityGroup,
       filesystemMountPoint: '/usr/src/apps/bot/db',
     })
   }

--- a/cdk/src/types.d.ts
+++ b/cdk/src/types.d.ts
@@ -2,10 +2,12 @@ import { StackProps } from 'aws-cdk-lib'
 import type * as ecs from 'aws-cdk-lib/aws-ecs'
 import type * as efs from 'aws-cdk-lib/aws-efs'
 import type * as ssm from 'aws-cdk-lib/aws-ssm'
+import type * as ec2 from 'aws-cdk-lib/aws-ec2'
 
 export interface HeyAmplifyAppStackProps extends StackProps {
   secrets: Record<string, ssm.IParameter>
   cluster: ecs.Cluster
   filesystem?: efs.FileSystem
+  filesystemSecurityGroup?: ec2.ISecurityGroup
   filesystemMountPoint?: string
 }


### PR DESCRIPTION
Fixes the cyclic error by lifting the security group out of the app construct and alongside the VPC its in