### PR TITLE
TRPC

### DIFF
--- a/packages/prisma-client/package.json
+++ b/packages/prisma-client/package.json
@@ -9,7 +9,9 @@
       "types": "./build/generated/client/index.d.ts"
     },
     "./package.json": "./package.json",
-    "./schema.prisma": "./schema.prisma"
+    "./schema.prisma": "./schema.prisma",
+    "./zod-types": "./build/zod-types/index.js",
+    "./zod-types/*": "./build/zod-types/*"
   },
   "types": "./build/generated/client/index.d.ts",
   "scripts": {
@@ -17,7 +19,9 @@
     "prepare": "prisma generate"
   },
   "dependencies": {
-    "@prisma/client": "^4.12.0"
+    "@prisma/client": "^4.12.0",
+    "zod": "^3.21.4",
+    "zod-prisma-types": "^2.5.6"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",

--- a/packages/prisma-client/schema.prisma
+++ b/packages/prisma-client/schema.prisma
@@ -11,6 +11,25 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+generator zod {
+  provider                         = "zod-prisma-types"
+  output                           = "./build/zod-types" // default is ./generated/zod
+  useMultipleFiles                 = true // default is false
+  createInputTypes                 = true // default is true
+  createModelTypes                 = true // default is true
+  addInputTypeValidation           = true // default is true
+  addIncludeType                   = true // default is true
+  addSelectType                    = true // default is true
+  validateWhereUniqueInput         = true // default is false
+  createOptionalDefaultValuesTypes = true // default is false
+  createRelationValuesTypes        = true // default is false
+  createPartialTypes               = true // default is false
+  useDefaultValidators             = false // default is true
+  coerceDate                       = false // default is true
+  writeNullishInModelTypes         = true // default is false
+  prismaClientPath                 = "../../generated/client" // default is client output path
+}
+
 model Guild {
   id            String          @id @unique
   createdAt     DateTime        @default(now())


### PR DESCRIPTION
Type issues have been solved. Using [zod-prisma-types](https://github.com/chrishoermann/zod-prisma-types), we can now generate input validators, model schemas, and output types when working with Prisma.

I've added `zod` and `zod-prisma-types` to the client package; in the future, these two go hand in hand with any interactions that need to perform using Prisma. 

At the moment creating TRPC routes is a bit wonky; for now, they will all be done by hand; however, I plan to create a fork of [prisma-trpc-generator](https://github.com/omar-dulaimi/prisma-trpc-generator) that will make this easier and use `zod-prisma-types` behind the scenes.